### PR TITLE
[IO] Improve image stack handling

### DIFF
--- a/src/PyMca5/PyMcaIO/HDF5Stack1D.py
+++ b/src/PyMca5/PyMcaIO/HDF5Stack1D.py
@@ -728,6 +728,13 @@ class HDF5Stack1D(DataObject.DataObject):
                                     xpath = scan + xSelection
                                     xDataset = hdf[xpath][()]
                                     xDatasetList.append(xDataset)
+                        try:
+                            yDataset = hdf[path][()]
+                            IN_MEMORY = True
+                        except (MemoryError, ValueError):
+                            _logger.info("Dynamic loading of images")
+                            yDataset = hdf[path]
+                            IN_MEMORY = False                     
                         if mSelection is not None:
                             nMonitorData = mDataset.size
                             case = -1
@@ -750,7 +757,11 @@ class HDF5Stack1D(DataObject.DataObject):
                                 for i in range(yDataset.shape[0]):
                                     self.data[i] += yDataset[i] / mDataset
                         else:
-                            self.data += yDataset
+                            if IN_MEMORY:
+                                self.data += yDataset
+                            else:
+                                for i in range(yDataset.shape[0]):
+                                    self.data[i:i+1] += yDataset[i:i+1]
         else:
             self.info["McaIndex"] = mcaIndex
             if _time:


### PR DESCRIPTION
The code as it was written was only dealing with a single dataset of images.

This PR makes sure if multiple scans and datasets are selected, they are properly summed.

It falls back to the case the data were not fitting into memory that was lost when avoiding a loop.