### PR TITLE
OutputBuffer datasets cannot be the same

### DIFF
--- a/src/PyMca5/PyMcaIO/OutputBuffer.py
+++ b/src/PyMca5/PyMcaIO/OutputBuffer.py
@@ -356,6 +356,8 @@ class OutputBuffer(MutableMapping):
         """
         if data is not None:
             buffer = numpy.asarray(data, dtype=dtype)
+            if id(buffer) in set(map(id, self._buffers.values())):
+                buffer = buffer.copy()
             if fill_value is not None:
                 buffer[:] = fill_value
         elif fill_value is None:


### PR DESCRIPTION
Closes #1123 

FYI the `OutputBuffer` is used by PyMca to send fit results to. The buffer takes care of allocating space in memory or HDF5 and saving the fit results in HDF5, EDF, TIF, DAT or CSV.

This bug concerns a pure in-memory space allocation: it does not ensure that each dataset is independent. So if I change the content of one dataset it does not affect another.