### PR TITLE
Fix min and max vaules in RGBCorrelator if numpy.nan exist in array

### DIFF
--- a/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -528,8 +528,8 @@ class RGBCorrelatorWidget(qt.QWidget):
                 )
                 self.__redImage = red
                 ddict["red"] = red.tobytes()
-
             ddict["size"] = size
+
         if "g" in colorlist:
             # get slider
             label = self.__greenLabel
@@ -675,8 +675,8 @@ class RGBCorrelatorWidget(qt.QWidget):
         self._imageDict[label] = {}
         self._imageDict[label]["image"] = image
         tmp = numpy.ravel(image)
-        self._imageDict[label]["min"] = min(tmp)
-        self._imageDict[label]["max"] = max(tmp)
+        self._imageDict[label]["min"] = numpy.nanmin(tmp)
+        self._imageDict[label]["max"] = numpy.nanmax(tmp)
 
         self.tableWidget.build(self._imageList)
         i = 0


### PR DESCRIPTION
To be able to open arrays with "nan".
Nature of problem is that default "min" and "max" could not handle "nan":
```
>>> c
array([[ 1.        ,  0.        ,         nan],
       [        nan,  1,  3.4       ],
       [-4.        ,  0.        ,  1.        ]])
>>> d
array([[  nan,  0.  , -0.12],
       [ 9.8 ,  1.  ,  3.  ],
       [-4.  ,  0.  ,  1.  ]])
>>> np.ravel(c)         
array([ 1.        ,  0.        ,         nan,         nan,  1,
        3.4       , -4.        ,  0.        ,  1.        ])
>>> np.ravel(d)                                                               
array([  nan,  0.  , -0.12,  9.8 ,  1.  ,  3.  , -4.  ,  0.  ,  1.  ])
>>> min(np.ravel(c))                                                          
np.float64(-4.0)
>>> min(np.ravel(d))    
np.float64(nan)
>>> np.nanmin(np.ravel(d)) 
np.float64(-4.0)
```