### PR TITLE
skip too long datasets to prevent crush

### DIFF
--- a/src/PyMca5/PyMcaGui/io/hdf5/HDF5CounterTable.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/HDF5CounterTable.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2023 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.

--- a/src/PyMca5/PyMcaGui/io/hdf5/HDF5CounterTable.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/HDF5CounterTable.py
@@ -73,7 +73,7 @@ class CntSelectionType(qt.QWidget):
             for dim in shape[:-1]:
                 maximum *= dim
         self._index.setMinimum(0)
-        if maximum:
+        if maximum and maximum < 2**31-1:
             self._index.setMaximum(maximum - 1)
         else:
             self._index.setMaximum(0)

--- a/src/PyMca5/PyMcaGui/io/hdf5/HDF5CounterTable.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/HDF5CounterTable.py
@@ -73,7 +73,7 @@ class CntSelectionType(qt.QWidget):
             for dim in shape[:-1]:
                 maximum *= dim
         self._index.setMinimum(0)
-        if maximum and maximum < 2**31-1:
+        if maximum:
             self._index.setMaximum(min(maximum,2**31)  - 1)
         else:
             self._index.setMaximum(0)

--- a/src/PyMca5/PyMcaGui/io/hdf5/HDF5CounterTable.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/HDF5CounterTable.py
@@ -74,7 +74,7 @@ class CntSelectionType(qt.QWidget):
                 maximum *= dim
         self._index.setMinimum(0)
         if maximum and maximum < 2**31-1:
-            self._index.setMaximum(maximum - 1)
+            self._index.setMaximum(min(maximum,2**31)  - 1)
         else:
             self._index.setMaximum(0)
         self._index.setValue(0)


### PR DESCRIPTION
When click on dataset in the group it adds all datasets to the table. If one dataset is too long it does not fit QSpinBox which leads to fact that any dataset from the group could not be displayed.
Rare and funny bug. 
I suggest just to skip such long datasets as one will not "spin" over 2 billion of layers.

<img width="1306" height="853" alt="Screenshot 2025-07-18 142213" src="https://github.com/user-attachments/assets/60690944-d682-450c-8a38-b89bcdfe6bc9" />
