### PR TITLE
Rgbcorrelator selector fix

### DIFF
--- a/src/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/src/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2023 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.
@@ -1307,10 +1307,16 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
     def __rgbCorrelator(self):
         if self.__correlator is None:
             self.__correlator = []
-        fileTypeList = ["Batch Result Files (*dat)",
-                        "EDF Files (*edf)",
-                        "EDF Files (*ccd)",
-                        "All Files (*)"]
+        fileTypeList = [
+            "HDF5 Files *.h5 *.nxs *.hdf *.hdf5",
+            "ASCII Files *dat",
+            "EDF Files *edf",
+            "EDF Files *ccd",
+            "CSV Files *csv",
+            "TIFF Files *tiff *tif",
+            "TextImage Files *txt",
+            "All Files *",
+        ]
         message = "Open ONE Batch result .dat file or SEVERAL EDF files"
         filelist = self.__getStackOfFiles(fileTypeList, message)
         if filelist:

--- a/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -582,6 +582,65 @@ class RGBCorrelatorWidget(qt.QWidget):
                 self.__blueImage = blue
                 ddict["blue"] = blue.tobytes()
             ddict["size"] = size
+
+        #whitening the nan pixels
+        for label in (self.__redLabel, self.__greenLabel, self.__blueLabel):
+          print(label)
+          if label is not None:
+            if bool(numpy.isnan(self._imageDict[label]["image"]).any()):
+                tmp = self._imageDict[label]["image"]
+                nan_indices = numpy.where(numpy.isnan(tmp))
+                if not 'r' in colorlist:
+                    nan_white = numpy.zeros(tmp.shape, dtype=numpy.uint8)
+                    nan_white[nan_indices[0], nan_indices[1]] = 255
+                    if USE_STRING:
+                        red = self.getColorImage(
+                            nan_white, spslut.RED, 0, 255,
+                        )[0]
+                        self.__redImage = numpy.array(red).astype(numpy.uint8)
+                        ddict['red'] = red
+                    else:
+                        red = self.getColorImage(
+                            nan_white, spslut.RED, 0, 255, 1
+                        )[0]
+                        self.__redImage = red
+                        ddict["red"] = red.tobytes()
+                if not 'g' in colorlist:
+                    nan_white = numpy.zeros(tmp.shape, dtype=numpy.uint8)
+                    nan_white[nan_indices[0], nan_indices[1]] = 255
+                    if USE_STRING:
+                        green = self.getColorImage(
+                            nan_white, spslut.GREEN, 0, 255,
+                        )[0]
+                        self.__redImage = numpy.array(green).astype(numpy.uint8)
+                        ddict['green'] = green
+                    else:
+                        green = self.getColorImage(
+                            nan_white, spslut.GREEN, 0, 255, 1
+                        )[0]
+                        self.__redImage = green
+                        ddict["green"] = green.tobytes()
+                if not 'b' in colorlist:
+                    nan_white = numpy.zeros(tmp.shape, dtype=numpy.uint8)
+                    nan_white[nan_indices[0], nan_indices[1]] = 255
+                    if USE_STRING:
+                        blue = self.getColorImage(
+                            nan_white, spslut.BLUE, 0, 255,
+                        )[0]
+                        self.__redImage = numpy.array(blue).astype(numpy.uint8)
+                        ddict['blue'] = blue
+                    else:
+                        blue = self.getColorImage(
+                            nan_white, spslut.BLUE, 0, 255, 1
+                        )[0]
+                        self.__redImage = blue
+                        ddict["blue"] = blue.tobytes()
+        print(self.__redImageData)
+        print(self.__greenImageData)
+        print(self.__blueImageData)
+        print(self.__redImage)
+        print(self.__greenImage)
+        print(self.__blueImage)
         image = self.__redImage + self.__greenImage + self.__blueImage
         ddict["image"] = image
         self.sigRGBCorrelatorWidgetSignal.emit(ddict)

--- a/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -504,6 +504,22 @@ class RGBCorrelatorWidget(qt.QWidget):
             colorlist = color * 1
         ddict = {}
         ddict["event"] = "updated"
+
+        # whitening the nan pixels
+        if bool(numpy.isnan(self.__redImageData).any()) or bool(numpy.isnan(self.__greenImageData).any()) or bool(numpy.isnan(self.__blueImageData).any()):
+            colorlist = ["r", "g", "b"]
+            nan_indices = numpy.where(numpy.isnan(self.__redImageData))
+            redImageData = numpy.copy(self.__redImageData)
+            greenImageData = numpy.copy(self.__greenImageData)
+            blueImageData = numpy.copy(self.__blueImageData)
+            redImageData[nan_indices[0], nan_indices[1]] = max(numpy.nanmax(self.__redImageData), 1) + 255
+            greenImageData[nan_indices[0], nan_indices[1]] = max(numpy.nanmax(self.__greenImageData), 1) + 255
+            blueImageData[nan_indices[0], nan_indices[1]] = max(numpy.nanmax(self.__blueImageData), 1) + 255
+        else:
+            redImageData = self.__redImageData
+            greenImageData = self.__greenImageData
+            blueImageData = self.__blueImageData
+
         if "r" in colorlist:
             # get slider
             label = self.__redLabel
@@ -518,13 +534,13 @@ class RGBCorrelatorWidget(qt.QWidget):
                 valmax = valmin + delta * self.__redMax
             if USE_STRING:
                 red, size, minmax = self.getColorImage(
-                    self.__redImageData, spslut.RED, valmin, valmax, 0
+                    redImageData, spslut.RED, valmin, valmax, 0
                 )
                 self.__redImage = numpy.array(red).astype(numpy.uint8)
                 ddict["red"] = red
             else:
                 red, size, minmax = self.getColorImage(
-                    self.__redImageData, spslut.RED, valmin, valmax, 1
+                    redImageData, spslut.RED, valmin, valmax, 1
                 )
                 self.__redImage = red
                 ddict["red"] = red.tobytes()
@@ -544,13 +560,13 @@ class RGBCorrelatorWidget(qt.QWidget):
                 valmax = valmin + delta * self.__greenMax
             if USE_STRING:
                 green, size, minmax = self.getColorImage(
-                    self.__greenImageData, spslut.GREEN, valmin, valmax
+                    greenImageData, spslut.GREEN, valmin, valmax
                 )
                 self.__greenImage = numpy.array(green).astype(numpy.uint8)
                 ddict["green"] = green
             else:
                 green, size, minmax = self.getColorImage(
-                    self.__greenImageData, spslut.GREEN, valmin, valmax, 1
+                    greenImageData, spslut.GREEN, valmin, valmax, 1
                 )
                 self.__greenImage = green
                 ddict["green"] = green.tobytes()
@@ -571,76 +587,18 @@ class RGBCorrelatorWidget(qt.QWidget):
                 valmax = valmin + delta * self.__blueMax
             if USE_STRING:
                 blue, size, minmax = self.getColorImage(
-                    self.__blueImageData, spslut.BLUE, valmin, valmax
+                    blueImageData, spslut.BLUE, valmin, valmax
                 )
                 self.__blueImage = numpy.array(blue).astype(numpy.uint8)
                 ddict["blue"] = blue
             else:
                 blue, size, minmax = self.getColorImage(
-                    self.__blueImageData, spslut.BLUE, valmin, valmax, 1
+                    blueImageData, spslut.BLUE, valmin, valmax, 1
                 )
                 self.__blueImage = blue
                 ddict["blue"] = blue.tobytes()
             ddict["size"] = size
 
-        #whitening the nan pixels
-        for label in (self.__redLabel, self.__greenLabel, self.__blueLabel):
-          print(label)
-          if label is not None:
-            if bool(numpy.isnan(self._imageDict[label]["image"]).any()):
-                tmp = self._imageDict[label]["image"]
-                nan_indices = numpy.where(numpy.isnan(tmp))
-                if not 'r' in colorlist:
-                    nan_white = numpy.zeros(tmp.shape, dtype=numpy.uint8)
-                    nan_white[nan_indices[0], nan_indices[1]] = 255
-                    if USE_STRING:
-                        red = self.getColorImage(
-                            nan_white, spslut.RED, 0, 255,
-                        )[0]
-                        self.__redImage = numpy.array(red).astype(numpy.uint8)
-                        ddict['red'] = red
-                    else:
-                        red = self.getColorImage(
-                            nan_white, spslut.RED, 0, 255, 1
-                        )[0]
-                        self.__redImage = red
-                        ddict["red"] = red.tobytes()
-                if not 'g' in colorlist:
-                    nan_white = numpy.zeros(tmp.shape, dtype=numpy.uint8)
-                    nan_white[nan_indices[0], nan_indices[1]] = 255
-                    if USE_STRING:
-                        green = self.getColorImage(
-                            nan_white, spslut.GREEN, 0, 255,
-                        )[0]
-                        self.__redImage = numpy.array(green).astype(numpy.uint8)
-                        ddict['green'] = green
-                    else:
-                        green = self.getColorImage(
-                            nan_white, spslut.GREEN, 0, 255, 1
-                        )[0]
-                        self.__redImage = green
-                        ddict["green"] = green.tobytes()
-                if not 'b' in colorlist:
-                    nan_white = numpy.zeros(tmp.shape, dtype=numpy.uint8)
-                    nan_white[nan_indices[0], nan_indices[1]] = 255
-                    if USE_STRING:
-                        blue = self.getColorImage(
-                            nan_white, spslut.BLUE, 0, 255,
-                        )[0]
-                        self.__redImage = numpy.array(blue).astype(numpy.uint8)
-                        ddict['blue'] = blue
-                    else:
-                        blue = self.getColorImage(
-                            nan_white, spslut.BLUE, 0, 255, 1
-                        )[0]
-                        self.__redImage = blue
-                        ddict["blue"] = blue.tobytes()
-        print(self.__redImageData)
-        print(self.__greenImageData)
-        print(self.__blueImageData)
-        print(self.__redImage)
-        print(self.__greenImage)
-        print(self.__blueImage)
         image = self.__redImage + self.__greenImage + self.__blueImage
         ddict["image"] = image
         self.sigRGBCorrelatorWidgetSignal.emit(ddict)

--- a/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2023 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.
@@ -506,15 +506,25 @@ class RGBCorrelatorWidget(qt.QWidget):
         ddict["event"] = "updated"
 
         # whitening the nan pixels
-        if bool(numpy.isnan(self.__redImageData).any()) or bool(numpy.isnan(self.__greenImageData).any()) or bool(numpy.isnan(self.__blueImageData).any()):
+        if (
+            bool(numpy.isnan(self.__redImageData).any())
+            or bool(numpy.isnan(self.__greenImageData).any())
+            or bool(numpy.isnan(self.__blueImageData).any())
+        ):
             colorlist = ["r", "g", "b"]
             nan_indices = numpy.where(numpy.isnan(self.__redImageData))
             redImageData = numpy.copy(self.__redImageData)
             greenImageData = numpy.copy(self.__greenImageData)
             blueImageData = numpy.copy(self.__blueImageData)
-            redImageData[nan_indices[0], nan_indices[1]] = max(numpy.nanmax(self.__redImageData), 1) + 255
-            greenImageData[nan_indices[0], nan_indices[1]] = max(numpy.nanmax(self.__greenImageData), 1) + 255
-            blueImageData[nan_indices[0], nan_indices[1]] = max(numpy.nanmax(self.__blueImageData), 1) + 255
+            redImageData[nan_indices[0], nan_indices[1]] = (
+                max(numpy.nanmax(self.__redImageData), 1) + 255
+            )
+            greenImageData[nan_indices[0], nan_indices[1]] = (
+                max(numpy.nanmax(self.__greenImageData), 1) + 255
+            )
+            blueImageData[nan_indices[0], nan_indices[1]] = (
+                max(numpy.nanmax(self.__blueImageData), 1) + 255
+            )
         else:
             redImageData = self.__redImageData
             greenImageData = self.__greenImageData

--- a/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/src/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -749,6 +749,12 @@ class RGBCorrelatorWidget(qt.QWidget):
         for label in labelList:
             self.removeImage(label)
 
+        # if all images removed then it is possible to choose different size.
+        if len(self._imageList) == 0:
+            self.__imageShape = None
+            self.__imageLength = None
+            self._updateSizeLabel()
+
     def removeImage(self, label):
         if label not in self._imageList:
             return
@@ -966,12 +972,12 @@ class RGBCorrelatorWidget(qt.QWidget):
         filedialog.setAcceptMode(qt.QFileDialog.AcceptMode.AcceptOpen)
         filedialog.setWindowIcon(qt.QIcon(qt.QPixmap(IconDict["gioconda16"])))
         formatlist = [
+            "HDF5 Files *.h5 *.nxs *.hdf *.hdf5",
             "ASCII Files *dat",
             "EDF Files *edf",
             "EDF Files *ccd",
             "CSV Files *csv",
             "TIFF Files *tiff *tif",
-            "HDF5 Files *.h5 *.nxs *.hdf *.hdf5",
             "TextImage Files *txt",
             "All Files *",
         ]
@@ -1100,13 +1106,20 @@ class RGBCorrelatorWidget(qt.QWidget):
         # Prompt for missing HDF5 path
         if not h5path:
             tmp = HDF5Widget.getUri(
-                parent=self, filename=filename, message="Select Group or Dataset"
+                parent=self, filename=filename, message="Select Group or Dataset", multi_selection=True
             )
             if not tmp:
                 return
-            tmp = tmp.split("::")
-            if len(tmp) == 2:
-                h5path = tmp[1]
+            self.bad_images_size = 0
+            if isinstance(tmp, list):
+                for item in tmp:
+                    self._addHf5File(item)
+                    if self.bad_images_size:
+                        break
+            else:
+                tmp = tmp.split("::")
+                if len(tmp) == 2:
+                    h5path = tmp[1]
         if not h5path:
             return
         # Add datasets from HDF5 path
@@ -1133,6 +1146,7 @@ class RGBCorrelatorWidget(qt.QWidget):
                     )
                 )
                 msg.exec()
+                self.bad_images_size = 1
                 self._addHf5File(filename, ignoreStDev=ignoreStDev)
             elif len({dset.size for dset in datasets}) > 1:
                 msg = qt.QMessageBox(self)

--- a/src/PyMca5/PyMcaIO/NexusUtils.py
+++ b/src/PyMca5/PyMcaIO/NexusUtils.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2019-2024 European Synchrotron Radiation Facility
+# Copyright (c) 2019-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -637,6 +637,13 @@ def selectDatasets(root, match=None):
     :param match: restrict selection (callable, 'max_ndim', 'mostcommon_ndim')
     :returns list(h5py.Dataset):
     """
+    # accept the list to hande multiple selection for h5 file
+    if isinstance(root, (list, tuple)):
+        datasets = []
+        for single_root in root:
+            datasets.extend(selectDatasets(single_root, match=match))
+        return datasets
+
     if match == 'max_ndim':
         match, post = None, match
     elif match == 'mostcommon_ndim':


### PR DESCRIPTION
Few small fixes for file selector of RGBCorrelator.
1) on first open add all available types it was:

<img width="550" height="436" alt="image" src="https://github.com/user-attachments/assets/322e55c4-b473-4ed2-8cc9-9bfede76c964" />

2) if all images were removed using red-cross button image size was still in memory not allowing to select an image with another size

<img width="253" height="259" alt="image" src="https://github.com/user-attachments/assets/170e97cd-b319-403a-ae64-c5b7abf0c62e" />

3) Add possibility to have multiple selection inside h5fille navigator. It is useful to select few out of many in one group, or to select few groups at a time. 